### PR TITLE
use ripgrep, ignore docs

### DIFF
--- a/find-first.sh
+++ b/find-first.sh
@@ -9,12 +9,16 @@ if which rg >& /dev/null; then
   cmd='rg'
 fi
 
-${cmd} "$@" *
+${cmd} "$@" 2???
 
 #First build with the problem
-BUILD=$(${cmd} -l "$@" * | awk -F '/' '{print $4}' | sort -n | head -n 1)
+BUILD=$(${cmd} -l "$@" 2??? | awk -F '/' '{print $4}' | sort -n | head -n 1)
 
-FAILED_BUILD_DIR=$(find * -name $BUILD -type d)
+if [[ -z "${BUILD}" ]]; then
+  exit 1
+fi
+
+FAILED_BUILD_DIR=$(find * -name "$BUILD" -type d)
 FIRST_FAILURE_COMMIT=$(jq -r '.jobs[0].head_sha' $FAILED_BUILD_DIR/job.json)
 echo "First failed commit: $FIRST_FAILURE_COMMIT"
 OZONE_DIR=${OZONE_DIR:-$PWD/../ozone}

--- a/find-first.sh
+++ b/find-first.sh
@@ -4,10 +4,15 @@
 
 set -eu
 
-grep -r "$@" *
+cmd='grep -r'
+if which rg >& /dev/null; then
+  cmd='rg'
+fi
+
+${cmd} "$@" *
 
 #First build with the problem
-BUILD=$(grep -r "$@" * | awk -F '/' '{print $4}' | sort -n  | head -n 1)
+BUILD=$(${cmd} -l "$@" * | awk -F '/' '{print $4}' | sort -n | head -n 1)
 
 FAILED_BUILD_DIR=$(find * -name $BUILD -type d)
 FIRST_FAILURE_COMMIT=$(jq -r '.jobs[0].head_sha' $FAILED_BUILD_DIR/job.json)


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Use [ripgrep](https://github.com/BurntSushi/ripgrep) if available, for faster search.
2. Only search in build result dirs (2020, etc.).  This prevents a bug that happens if HTML report in `docs` also contains the search string:
   ```bash
   $ ./find-first.sh testWatchForCommitForGroupMismatchException
   ...
   find: d: unknown primary or operator
   ```

## How was this patch tested?

```bash
$ ./find-first.sh testWatchForCommitForGroupMismatchException
2020/06/27/1251/it-client/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.client.rpc.TestWatchForCommit.xml
75:  <testcase name="testWatchForCommitForGroupMismatchException" classname="org.apache.hadoop.ozone.client.rpc.TestWatchForCommit" time="38.374"/>
2629:	at org.apache.hadoop.ozone.client.rpc.TestWatchForCommit.testWatchForCommitForGroupMismatchException(TestWatchForCommit.java:338)
...
First failed commit: 0f2a11827db011eb9902adcf867cbe8f6af5116c
* 2020-06-27 09:53:50 +0200 0f2a11827 U -  HDDS-3757. Add test coverage of the acceptance tests to overall test coverage  (#1050) <Elek, Márton> <GitHub>
* 2020-06-26 15:13:14 -0700 90c17ca6a U -  HDDS-3615. Call cleanup on tables only when double buffer has transactions related to tables. (#943) <Bharat Viswanadham> <GitHub>
...
```

```bash
$ time ./find-first.sh multipart.S3MultipartUploadAbortRequest
...
  1.42s user 4.21s system 193% cpu 2.920 total

$ git checkout master
$ time ./find-first.sh multipart.S3MultipartUploadAbortRequest
...
 45.84s user 3.81s system 88% cpu 56.076 total
```