### PR TITLE
avoid adding 100MB+ files

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 ./ogh archive `pwd`
 ./ogh report `pwd`
+find * -size '+100M' | xargs rm -v
 git add .
 git config user.email "ci@github.com"
 git config user.name "Github Actions"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Avoid adding 100MB+ files to git, because GitHub will reject these and update stops working.  (Ideally we'll need a similar change in `ogh` to avoid downloading these in the first place, if possible.)

```
remote: error: File 2021/02/02/5676/it-client/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.client.rpc.TestKeyInputStream.xml is 248.02 MB; this exceeds GitHub's file size limit of 100.00 MB
remote: error: File 2021/02/02/5676/it-client/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestKeyInputStream-output.txt is 1273.93 MB; this exceeds GitHub's file size limit of 100.00 MB
To https://github.com/elek/ozone-build-results
 ! [remote rejected]   master -> master (pre-receive hook declined)
```

## How was this patch tested?

```
$ ogh archive $(pwd)
$ find * -size '+100M' | xargs rm -v
2021/02/02/5676/it-client/hadoop-ozone/integration-test/TEST-org.apache.hadoop.ozone.client.rpc.TestKeyInputStream.xml
2021/02/02/5676/it-client/hadoop-ozone/integration-test/org.apache.hadoop.ozone.client.rpc.TestKeyInputStream-output.txt
```